### PR TITLE
Mostrar notas solo si se cierra el periodo - Boletines BBA

### DIFF
--- a/apps/backend/modules/report_card/templates/_course_subject_bimester.php
+++ b/apps/backend/modules/report_card/templates/_course_subject_bimester.php
@@ -35,7 +35,7 @@
       <td class='subject_name'><?php echo $course_subject_student->getCourseSubject()->getCareerSubject()->getSubject()->getName() ?></td>
       <?php #Imprimimos las notas del PRIMER bimester?>
       <?php for ($mark_number = 1; $mark_number <= $course_subject_student->getCourseSubject()->countMarks(); $mark_number++): ?>
-        <td><?php echo $course_subject_student->getMarkForIsClose($mark_number) ?></td>
+        <td><?php echo $course_subject_student->getMarkForIsClosed($mark_number) ?></td>
       <?php endfor; ?>
       <?php #Completo los casilleros extras que  tienen si mi materia tiene menos notas que  el maximo del bimestre?>
       <?php if ($max_marks_first_q > $course_subject_student->getCourseSubject()->countMarks()): ?>
@@ -98,7 +98,7 @@
       <td class='subject_name'><?php echo $course_subject_student->getCourseSubject()->getCareerSubject()->getSubject()->getName() ?></td>
       <?php #Imprimimos las notas del SEGUNDO bimester ?>
       <?php for ($mark_number = 1; $mark_number <= $course_subject_student->getCourseSubject()->countMarks(); $mark_number++): ?>
-        <td><?php echo $course_subject_student->getMarkForIsClose($mark_number) ?></td>
+        <td><?php echo $course_subject_student->getMarkForIsClosed($mark_number) ?></td>
       <?php endfor; ?>
       <?php #Completo los casilleros extras que  tienen si mi materia tiene menos notas que  el maximo del bimestre?>
       <?php if ($max_marks_second_q > $course_subject_student->getCourseSubject()->countMarks()): ?>

--- a/apps/backend/modules/report_card/templates/_course_subject_quaterly.php
+++ b/apps/backend/modules/report_card/templates/_course_subject_quaterly.php
@@ -31,7 +31,7 @@
         <?php echo $course_subject_student->getCourseSubject()->getCareerSubject()->getSubject()->getName() ?></td>
 
       <?php for ($mark_number = 1; $mark_number <= $course_subject_student->getCourseSubject()->countMarks() ; $mark_number++): ?>
-        <td><?php echo $course_subject_student->getMarkForIsClose($mark_number) ?></td>
+        <td><?php echo $course_subject_student->getMarkForIsClosed($mark_number) ?></td>
       <?php endfor; ?>
 
       <?php $course_result = $course_subject_student->getCourseResult() ?>

--- a/apps/backend/modules/report_card/templates/_course_subject_trimester.php
+++ b/apps/backend/modules/report_card/templates/_course_subject_trimester.php
@@ -35,7 +35,7 @@
       <td class='subject_name'><?php echo $course_subject_student->getCourseSubject()->getCareerSubject()->getSubject()->getName() ?></td>
 
       <?php for ($mark_number = 1; $mark_number <= $max_marks; $mark_number++): ?>
-        <td><?php echo $course_subject_student->getMarkForIsClose($mark_number) ?></td>
+        <td><?php echo $course_subject_student->getMarkForIsClosed($mark_number) ?></td>
       <?php endfor; ?>
       <?php $course_result = $course_subject_student->getCourseResult() ?>
       <?php if (!$course_subject_student->hasSomeMarkFree()): ?>

--- a/flavors/agropecuaria/lib/behaviour/AgropecuariaEvaluatorBehaviour.class.php
+++ b/flavors/agropecuaria/lib/behaviour/AgropecuariaEvaluatorBehaviour.class.php
@@ -131,9 +131,9 @@ class AgropecuariaEvaluatorBehaviour extends BaseEvaluatorBehaviour
 
     foreach ($course_subject_students as $course_subject_student)
     {
-      if (!is_null($course_subject_student->getMarkForIsClose($number)))
+      if (!is_null($course_subject_student->getMarkForIsClosed($number)))
       {
-        $partial_avg = bcadd($partial_avg, $course_subject_student->getMarkForIsClose($number)->getMark(), 2);
+        $partial_avg = bcadd($partial_avg, $course_subject_student->getMarkForIsClosed($number)->getMark(), 2);
       }
     }
     return bcdiv($partial_avg, count($course_subject_students), 2);
@@ -145,7 +145,7 @@ class AgropecuariaEvaluatorBehaviour extends BaseEvaluatorBehaviour
 
     foreach ($course_subject_students as $course_subject_student)
     {
-      $last_mark_is_closed = $course_subject_student->getLastMarkForIsClose();
+      $last_mark_is_closed = $course_subject_student->getLastMarkForIsClosed();
       $partial_avg = bcadd($partial_avg, $last_mark_is_closed->getMark(), 2);
     }
 

--- a/flavors/agropecuaria/modules/report_card/templates/_course_subject_quaterly.php
+++ b/flavors/agropecuaria/modules/report_card/templates/_course_subject_quaterly.php
@@ -53,11 +53,11 @@
 
 
             <?php if ($config && $config->parentIsFirst()): ?>
-            <td><?php echo $course_subject_student->getMarkForIsClose($mark_number) ?></td>
+            <td><?php echo $course_subject_student->getMarkForIsClosed($mark_number) ?></td>
             <td>--</td>
           <?php else: ?>
             <td>--</td>
-            <td><?php echo $course_subject_student->getMarkForIsClose($mark_number) ?></td>
+            <td><?php echo $course_subject_student->getMarkForIsClosed($mark_number) ?></td>
           <?php endif; ?>
 
 
@@ -66,14 +66,14 @@
           <?php $configs = $course_subject_student->getCourseSubject()->getCourseSubjectConfigurations(); ?>
           <?php $config = array_shift($configs); ?>
       <?php if ($config && $config->isForFirstQuaterly()): ?>
-            <td><?php echo $course_subject_student->getMarkForIsClose($mark_number) ?></td>
+            <td><?php echo $course_subject_student->getMarkForIsClosed($mark_number) ?></td>
             <td>--</td>
           <?php else: ?>
             <td>--</td>
-            <td><?php echo $course_subject_student->getMarkForIsClose($mark_number) ?></td>
+            <td><?php echo $course_subject_student->getMarkForIsClosed($mark_number) ?></td>
           <?php endif; ?>
         <?php else: ?>
-          <td><?php echo $course_subject_student->getMarkForIsClose($mark_number) ?></td>
+          <td><?php echo $course_subject_student->getMarkForIsClosed($mark_number) ?></td>
     <?php endif; ?>
     <?php endif; ?>
       <?php endfor; ?>

--- a/flavors/agropecuaria/modules/report_card/templates/_course_subjects.php
+++ b/flavors/agropecuaria/modules/report_card/templates/_course_subjects.php
@@ -33,8 +33,8 @@
       <td><?php echo SchoolBehaviourFactory::getEvaluatorInstance()->getExemptString() ?></td>
       <td><?php echo SchoolBehaviourFactory::getEvaluatorInstance()->getExemptString() ?></td>
       <?php else: ?>
-      <td><?php echo $course_subject_student->getMarkForIsClose(1) ?></td>
-      <td><?php echo $course_subject_student->getMarkForIsClose(2) ?></td>
+      <td><?php echo $course_subject_student->getMarkForIsClosed(1) ?></td>
+      <td><?php echo $course_subject_student->getMarkForIsClosed(2) ?></td>
       <?php endif; ?>
       <td><?php echo ($course_result = $course_subject_student->getCourseResult()) ? $course_result->getResultStr() : '' ?></td>
       <td><?php echo (($course_result instanceOf StudentDisapprovedCourseSubject) && $course_subject_student_examination = $course_subject_student->getCourseSubjectStudentExaminationsForExaminationNumber(1)) ? $course_subject_student_examination->getMarkStr() : '' ?></td>

--- a/flavors/anexa/modules/report_card/templates/_course_subject_bimester.php
+++ b/flavors/anexa/modules/report_card/templates/_course_subject_bimester.php
@@ -52,7 +52,7 @@
 			<td class='subject_name'><?php echo $course_subject_student->getCourseSubject()->getCareerSubject()->getSubject()->getName() ?></td>
 			<?php #Imprimimos las notas del PRIMER bimester?>
 			<?php for ($mark_number = 1; $mark_number <= $course_subject_student->getCourseSubject()->countMarks(); $mark_number++): ?>
-				<td><?php echo $course_subject_student->getMarkForIsClose($mark_number) ?></td>
+				<td><?php echo $course_subject_student->getMarkForIsClosed($mark_number) ?></td>
 			<?php endfor; ?>
 			<?php #Completo los casilleros extras que  tienen si mi materia tiene menos notas que  el maximo del bimestre?>
 			<?php if ($max_marks_first_q > $course_subject_student->getCourseSubject()->countMarks()): ?>
@@ -122,7 +122,7 @@
 			<td class='subject_name'><?php echo $course_subject_student->getCourseSubject()->getCareerSubject()->getSubject()->getName() ?></td>
 			<?php #Imprimimos las notas del SEGUNDO bimester ?>
 			<?php for ($mark_number = 1; $mark_number <= $course_subject_student->getCourseSubject()->countMarks(); $mark_number++): ?>
-				<td><?php echo $course_subject_student->getMarkForIsClose($mark_number) ?></td>
+				<td><?php echo $course_subject_student->getMarkForIsClosed($mark_number) ?></td>
 			<?php endfor; ?>
 			<?php #Completo los casilleros extras que  tienen si mi materia tiene menos notas que  el maximo del bimestre?>
 			<?php if ($max_marks_second_q > $course_subject_student->getCourseSubject()->countMarks()): ?>

--- a/flavors/anexa/modules/report_card/templates/_course_subject_trimester.php
+++ b/flavors/anexa/modules/report_card/templates/_course_subject_trimester.php
@@ -47,7 +47,7 @@
 				<td class='subject_name'><?php echo $course_subject_student->getCourseSubject()->getCareerSubject()->getSubject()->getName() ?></td>
 
 				<?php for ($mark_number = 1; $mark_number <= $max_marks; $mark_number++): ?>
-					<td><?php echo $course_subject_student->getMarkForIsClose($mark_number) ?></td>
+					<td><?php echo $course_subject_student->getMarkForIsClosed($mark_number) ?></td>
 				<?php endfor; ?>
 				<?php $course_result = $course_subject_student->getCourseResult() ?>
 				<?php if (!$course_subject_student->hasSomeMarkFree()): ?>

--- a/flavors/bba/modules/report_card/templates/_course_subject_bimester.php
+++ b/flavors/bba/modules/report_card/templates/_course_subject_bimester.php
@@ -26,9 +26,9 @@
   <?php foreach ($course_subject_students_first_q as $course_subject_student): ?>
     <tr>
       <td class='subject_name'><?php echo $course_subject_student->getCourseSubject()->getCareerSubject()->getSubject()->getName() ?></td>
-      <td><?php echo $course_subject_student->getMarkForIsClose(1) ?></td>
-      <td><?php echo $course_subject_student->getMarkForIsClose(2) ?></td>
-      <td><?php echo $course_subject_student->getMarkForIsClose(3) ?></td>
+      <td><?php echo $course_subject_student->getMarkForIsClosed(1) ?></td>
+      <td><?php echo $course_subject_student->getMarkForIsClosed(2) ?></td>
+      <td><?php echo $course_subject_student->getMarkForIsClosed(3) ?></td>
 
       <td><?php echo ($course_result = $course_subject_student->getCourseResult()) ? $course_result->getResultStr() : '' ?></td>
       <td><?php echo (($course_result instanceOf StudentDisapprovedCourseSubject) && $course_subject_student_examination = $course_subject_student->getCourseSubjectStudentExaminationsForExaminationNumber(1)) ? $course_subject_student_examination->getMarkStr() : '' ?></td>
@@ -55,9 +55,9 @@
   <?php foreach ($course_subject_students_second_q as $course_subject_student): ?>
     <tr>
       <td class='subject_name'><?php echo $course_subject_student->getCourseSubject()->getCareerSubject()->getSubject()->getName() ?></td>
-      <td><?php echo $course_subject_student->getMarkForIsClose(1) ?></td>
-      <td><?php echo $course_subject_student->getMarkForIsClose(2) ?></td>
-      <td><?php echo $course_subject_student->getMarkForIsClose(3) ?></td>
+      <td><?php echo $course_subject_student->getMarkForIsClosed(1) ?></td>
+      <td><?php echo $course_subject_student->getMarkForIsClosed(2) ?></td>
+      <td><?php echo $course_subject_student->getMarkForIsClosed(3) ?></td>
       <td><?php echo ($course_result = $course_subject_student->getCourseResult()) ? $course_result->getResultStr() : '' ?></td>
       <td><?php echo (($course_result instanceOf StudentDisapprovedCourseSubject) && $course_subject_student_examination = $course_subject_student->getCourseSubjectStudentExaminationsForExaminationNumber(1)) ? $course_subject_student_examination->getMarkStr() : '' ?></td>
       <td><?php echo (($course_result instanceOf StudentDisapprovedCourseSubject) && $course_subject_student_examination = $course_subject_student->getCourseSubjectStudentExaminationsForExaminationNumber(2)) ? $course_subject_student_examination->getMarkStr() : '' ?></td>

--- a/flavors/bba/modules/report_card/templates/_course_subject_bimester.php
+++ b/flavors/bba/modules/report_card/templates/_course_subject_bimester.php
@@ -26,9 +26,9 @@
   <?php foreach ($course_subject_students_first_q as $course_subject_student): ?>
     <tr>
       <td class='subject_name'><?php echo $course_subject_student->getCourseSubject()->getCareerSubject()->getSubject()->getName() ?></td>
-      <td><?php echo $course_subject_student->getMarkFor(1) ?></td>
-      <td><?php echo $course_subject_student->getMarkFor(2) ?></td>
-      <td><?php echo $course_subject_student->getMarkFor(3) ?></td>
+      <td><?php echo $course_subject_student->getMarkForIsClose(1) ?></td>
+      <td><?php echo $course_subject_student->getMarkForIsClose(2) ?></td>
+      <td><?php echo $course_subject_student->getMarkForIsClose(3) ?></td>
 
       <td><?php echo ($course_result = $course_subject_student->getCourseResult()) ? $course_result->getResultStr() : '' ?></td>
       <td><?php echo (($course_result instanceOf StudentDisapprovedCourseSubject) && $course_subject_student_examination = $course_subject_student->getCourseSubjectStudentExaminationsForExaminationNumber(1)) ? $course_subject_student_examination->getMarkStr() : '' ?></td>
@@ -55,9 +55,9 @@
   <?php foreach ($course_subject_students_second_q as $course_subject_student): ?>
     <tr>
       <td class='subject_name'><?php echo $course_subject_student->getCourseSubject()->getCareerSubject()->getSubject()->getName() ?></td>
-      <td><?php echo $course_subject_student->getMarkFor(1) ?></td>
-      <td><?php echo $course_subject_student->getMarkFor(2) ?></td>
-      <td><?php echo $course_subject_student->getMarkFor(3) ?></td>
+      <td><?php echo $course_subject_student->getMarkForIsClose(1) ?></td>
+      <td><?php echo $course_subject_student->getMarkForIsClose(2) ?></td>
+      <td><?php echo $course_subject_student->getMarkForIsClose(3) ?></td>
       <td><?php echo ($course_result = $course_subject_student->getCourseResult()) ? $course_result->getResultStr() : '' ?></td>
       <td><?php echo (($course_result instanceOf StudentDisapprovedCourseSubject) && $course_subject_student_examination = $course_subject_student->getCourseSubjectStudentExaminationsForExaminationNumber(1)) ? $course_subject_student_examination->getMarkStr() : '' ?></td>
       <td><?php echo (($course_result instanceOf StudentDisapprovedCourseSubject) && $course_subject_student_examination = $course_subject_student->getCourseSubjectStudentExaminationsForExaminationNumber(2)) ? $course_subject_student_examination->getMarkStr() : '' ?></td>

--- a/flavors/bba/modules/report_card/templates/_course_subject_quaterly.php
+++ b/flavors/bba/modules/report_card/templates/_course_subject_quaterly.php
@@ -25,9 +25,9 @@
   <?php foreach ($course_subject_students as $course_subject_student): ?>
     <tr>
       <td class='subject_name'><?php echo $course_subject_student->getCourseSubject()->getCareerSubject()->getSubject()->getName() ?></td>
-      <td><?php echo $course_subject_student->getMarkForIsClose(1) ?></td>
-      <td><?php echo $course_subject_student->getMarkForIsClose(2) ?></td>
-      <td><?php echo $course_subject_student->getMarkForIsClose(3) ?></td>
+      <td><?php echo $course_subject_student->getMarkForIsClosed(1) ?></td>
+      <td><?php echo $course_subject_student->getMarkForIsClosed(2) ?></td>
+      <td><?php echo $course_subject_student->getMarkForIsClosed(3) ?></td>
       <td><?php echo ($course_result = $course_subject_student->getCourseResult()) ? $course_result->getResultStr() : '' ?></td>
       <td><?php echo (($course_result instanceOf StudentDisapprovedCourseSubject) && $course_subject_student_examination = $course_subject_student->getCourseSubjectStudentExaminationsForExaminationNumber(1)) ? $course_subject_student_examination->getMarkStr() : '' ?></td>
       <td><?php echo (($course_result instanceOf StudentDisapprovedCourseSubject) && $course_subject_student_examination = $course_subject_student->getCourseSubjectStudentExaminationsForExaminationNumber(2)) ? $course_subject_student_examination->getMarkStr() : '' ?></td>

--- a/flavors/bba/modules/report_card/templates/_course_subject_quaterly.php
+++ b/flavors/bba/modules/report_card/templates/_course_subject_quaterly.php
@@ -25,9 +25,9 @@
   <?php foreach ($course_subject_students as $course_subject_student): ?>
     <tr>
       <td class='subject_name'><?php echo $course_subject_student->getCourseSubject()->getCareerSubject()->getSubject()->getName() ?></td>
-      <td><?php echo $course_subject_student->getMarkFor(1) ?></td>
-      <td><?php echo $course_subject_student->getMarkFor(2) ?></td>
-      <td><?php echo $course_subject_student->getMarkFor(3) ?></td>
+      <td><?php echo $course_subject_student->getMarkForIsClose(1) ?></td>
+      <td><?php echo $course_subject_student->getMarkForIsClose(2) ?></td>
+      <td><?php echo $course_subject_student->getMarkForIsClose(3) ?></td>
       <td><?php echo ($course_result = $course_subject_student->getCourseResult()) ? $course_result->getResultStr() : '' ?></td>
       <td><?php echo (($course_result instanceOf StudentDisapprovedCourseSubject) && $course_subject_student_examination = $course_subject_student->getCourseSubjectStudentExaminationsForExaminationNumber(1)) ? $course_subject_student_examination->getMarkStr() : '' ?></td>
       <td><?php echo (($course_result instanceOf StudentDisapprovedCourseSubject) && $course_subject_student_examination = $course_subject_student->getCourseSubjectStudentExaminationsForExaminationNumber(2)) ? $course_subject_student_examination->getMarkStr() : '' ?></td>

--- a/flavors/bba/modules/report_card/templates/_course_subject_quaterly_2_marks.php
+++ b/flavors/bba/modules/report_card/templates/_course_subject_quaterly_2_marks.php
@@ -35,8 +35,8 @@
 	<?php foreach ($course_subject_students as $course_subject_student): ?>
 		<tr>
 			<td class='subject_name'><?php echo $course_subject_student->getCourseSubject()->getCareerSubject()->getSubject()->getName() ?></td>
-			<td><?php echo $course_subject_student->getMarkFor(1) ?></td>
-			<td><?php echo $course_subject_student->getMarkFor(2) ?></td>
+			<td><?php echo $course_subject_student->getMarkForIsClose(1) ?></td>
+			<td><?php echo $course_subject_student->getMarkForIsClose(2) ?></td>
 			<td><?php echo ($course_result = $course_subject_student->getCourseResult()) ? $course_result->getResultStr() : '' ?></td>
 			<td><?php echo (($course_result instanceOf StudentDisapprovedCourseSubject) && $course_subject_student_examination = $course_subject_student->getCourseSubjectStudentExaminationsForExaminationNumber(1)) ? $course_subject_student_examination->getMarkStr() : '' ?></td>
 			<td><?php echo (($course_result instanceOf StudentDisapprovedCourseSubject) && $course_subject_student_examination = $course_subject_student->getCourseSubjectStudentExaminationsForExaminationNumber(2)) ? $course_subject_student_examination->getMarkStr() : '' ?></td>

--- a/flavors/bba/modules/report_card/templates/_course_subject_quaterly_2_marks.php
+++ b/flavors/bba/modules/report_card/templates/_course_subject_quaterly_2_marks.php
@@ -35,8 +35,8 @@
 	<?php foreach ($course_subject_students as $course_subject_student): ?>
 		<tr>
 			<td class='subject_name'><?php echo $course_subject_student->getCourseSubject()->getCareerSubject()->getSubject()->getName() ?></td>
-			<td><?php echo $course_subject_student->getMarkForIsClose(1) ?></td>
-			<td><?php echo $course_subject_student->getMarkForIsClose(2) ?></td>
+			<td><?php echo $course_subject_student->getMarkForIsClosed(1) ?></td>
+			<td><?php echo $course_subject_student->getMarkForIsClosed(2) ?></td>
 			<td><?php echo ($course_result = $course_subject_student->getCourseResult()) ? $course_result->getResultStr() : '' ?></td>
 			<td><?php echo (($course_result instanceOf StudentDisapprovedCourseSubject) && $course_subject_student_examination = $course_subject_student->getCourseSubjectStudentExaminationsForExaminationNumber(1)) ? $course_subject_student_examination->getMarkStr() : '' ?></td>
 			<td><?php echo (($course_result instanceOf StudentDisapprovedCourseSubject) && $course_subject_student_examination = $course_subject_student->getCourseSubjectStudentExaminationsForExaminationNumber(2)) ? $course_subject_student_examination->getMarkStr() : '' ?></td>

--- a/flavors/bba/modules/report_card/templates/_course_subject_trimester.php
+++ b/flavors/bba/modules/report_card/templates/_course_subject_trimester.php
@@ -23,9 +23,9 @@
   <?php foreach ($course_subject_students as $course_subject_student): ?>
     <tr>
       <td class='subject_name'><?php echo $course_subject_student->getCourseSubject()->getCareerSubject()->getSubject()->getName() ?></td>
-      <td><?php echo $course_subject_student->getMarkForIsClose(1) ?></td>
-      <td><?php echo $course_subject_student->getMarkForIsClose(2) ?></td>
-      <td><?php echo $course_subject_student->getMarkForIsClose(3) ?></td>
+      <td><?php echo $course_subject_student->getMarkForIsClosed(1) ?></td>
+      <td><?php echo $course_subject_student->getMarkForIsClosed(2) ?></td>
+      <td><?php echo $course_subject_student->getMarkForIsClosed(3) ?></td>
       <td><?php echo ($course_result = $course_subject_student->getCourseResult()) ? $course_result->getResultStr() : '' ?></td>
       <td><?php echo (($course_result instanceOf StudentDisapprovedCourseSubject) && $course_subject_student_examination = $course_subject_student->getCourseSubjectStudentExaminationsForExaminationNumber(1)) ? $course_subject_student_examination->getMarkStr() : '' ?></td>
       <td><?php echo (($course_result instanceOf StudentDisapprovedCourseSubject) && $course_subject_student_examination = $course_subject_student->getCourseSubjectStudentExaminationsForExaminationNumber(2)) ? $course_subject_student_examination->getMarkStr() : '' ?></td>

--- a/flavors/bba/modules/report_card/templates/_course_subject_trimester.php
+++ b/flavors/bba/modules/report_card/templates/_course_subject_trimester.php
@@ -23,9 +23,9 @@
   <?php foreach ($course_subject_students as $course_subject_student): ?>
     <tr>
       <td class='subject_name'><?php echo $course_subject_student->getCourseSubject()->getCareerSubject()->getSubject()->getName() ?></td>
-      <td><?php echo $course_subject_student->getMarkFor(1) ?></td>
-      <td><?php echo $course_subject_student->getMarkFor(2) ?></td>
-      <td><?php echo $course_subject_student->getMarkFor(3) ?></td>
+      <td><?php echo $course_subject_student->getMarkForIsClose(1) ?></td>
+      <td><?php echo $course_subject_student->getMarkForIsClose(2) ?></td>
+      <td><?php echo $course_subject_student->getMarkForIsClose(3) ?></td>
       <td><?php echo ($course_result = $course_subject_student->getCourseResult()) ? $course_result->getResultStr() : '' ?></td>
       <td><?php echo (($course_result instanceOf StudentDisapprovedCourseSubject) && $course_subject_student_examination = $course_subject_student->getCourseSubjectStudentExaminationsForExaminationNumber(1)) ? $course_subject_student_examination->getMarkStr() : '' ?></td>
       <td><?php echo (($course_result instanceOf StudentDisapprovedCourseSubject) && $course_subject_student_examination = $course_subject_student->getCourseSubjectStudentExaminationsForExaminationNumber(2)) ? $course_subject_student_examination->getMarkStr() : '' ?></td>

--- a/lib/model/CourseSubjectStudent.php
+++ b/lib/model/CourseSubjectStudent.php
@@ -110,7 +110,7 @@ class CourseSubjectStudent extends BaseCourseSubjectStudent
    * @param <type> $mark_number
    * @return  CourseSubjectStudentMark
    */
-  public function getMarkForIsClose($mark_number, PropelPDO $con = null)
+  public function getMarkForIsClosed($mark_number, PropelPDO $con = null)
   {
     $mark = $this->getMarkFor($mark_number);
   
@@ -125,7 +125,7 @@ class CourseSubjectStudent extends BaseCourseSubjectStudent
 
   }
 
-  public function getLastMarkForIsClose(PropelPDO $con = null)
+  public function getLastMarkForIsClosed(PropelPDO $con = null)
   {
     $mark_number = 0;
     /* @var $mark CourseSubjectStudentMark */


### PR DESCRIPTION
- Se modifico la forma de mostrar las notras de las materias en el boletin, ahora se muestran solo cuando el periodo esta cerrado.