### PR TITLE
Condicion para materias eximidas considerarlas aprobadas para el promedio.

### DIFF
--- a/lib/school_behaviour/base/BaseEvaluatorBehaviour.class.php
+++ b/lib/school_behaviour/base/BaseEvaluatorBehaviour.class.php
@@ -651,7 +651,6 @@ class BaseEvaluatorBehaviour extends InterfaceEvaluatorBehaviour
 
   public function getAnualAverageForStudentCareerSchoolYear($student_career_school_year)
   {
-
     if ($this->hasApprovedAllCourseSubjects($student_career_school_year))
     {
       $sum = 0;
@@ -688,14 +687,18 @@ class BaseEvaluatorBehaviour extends InterfaceEvaluatorBehaviour
     /* @var $course_subject_student CourseSubjectStudent */
     foreach ($course_subject_students as $course_subject_student)
     {
-      $course_result = $course_subject_student->getCourseResult();
-      if (is_null($course_result))
+      if(!$course_subject_student->getIsNotAverageable())
       {
-        return false;
+        $course_result = $course_subject_student->getCourseResult();
+        if (is_null($course_result))
+        {
+          return false;
+        }
+
+        if (!$course_result->isApproved())
+          return false;
       }
 
-      if (!$course_result->isApproved())
-        return false;
     }
 
     return true;


### PR DESCRIPTION
- Modificacion en el Base Evaluator para considerar materias eximidas como materias aprobadas a la hora de evaluar si tiene todas aprobadas.